### PR TITLE
feat: add total amount instance to contract class details

### DIFF
--- a/services/explorer-ui/src/components/contracts/instances/table.tsx
+++ b/services/explorer-ui/src/components/contracts/instances/table.tsx
@@ -5,6 +5,7 @@ import { contractsTableColumns } from "./columns";
 
 interface Props {
   title?: string;
+  description?: string;
   contracts?: ContractInstance[];
   isLoading: boolean;
   error?: Error | null;
@@ -14,12 +15,17 @@ interface Props {
 export const ContractInstancesTable: FC<Props> = ({
   title,
   contracts,
+  description,
   isLoading,
   error,
   showContractVersions,
 }) => {
-  if (!contracts) { return <div>No data</div>; }
-  if (error) { return <p className="text-red-500">{error.message}</p>; }
+  if (!contracts) {
+    return <div>No data</div>;
+  }
+  if (error) {
+    return <p className="text-red-500">{error.message}</p>;
+  }
   let cols = contractsTableColumns;
   if (!showContractVersions) {
     cols = contractsTableColumns.filter((column) => {
@@ -30,11 +36,8 @@ export const ContractInstancesTable: FC<Props> = ({
     <section className="relative mx-auto w-full transition-all">
       <div className="space-y-4 bg-white rounded-lg p-5">
         {title && <h3 className="ml-0.5">{title}</h3>}
-        <DataTable
-          isLoading={isLoading}
-          data={contracts}
-          columns={cols}
-        />
+        {description && <p className="text-sm text-primary">{description}</p>}
+        <DataTable isLoading={isLoading} data={contracts} columns={cols} />
       </div>
     </section>
   );

--- a/services/explorer-ui/src/components/contracts/instances/table.tsx
+++ b/services/explorer-ui/src/components/contracts/instances/table.tsx
@@ -5,7 +5,6 @@ import { contractsTableColumns } from "./columns";
 
 interface Props {
   title?: string;
-  description?: string;
   contracts?: ContractInstance[];
   isLoading: boolean;
   error?: Error | null;
@@ -15,7 +14,6 @@ interface Props {
 export const ContractInstancesTable: FC<Props> = ({
   title,
   contracts,
-  description,
   isLoading,
   error,
   showContractVersions,
@@ -36,7 +34,6 @@ export const ContractInstancesTable: FC<Props> = ({
     <section className="relative mx-auto w-full transition-all">
       <div className="space-y-4 bg-white rounded-lg p-5">
         {title && <h3 className="ml-0.5">{title}</h3>}
-        {description && <p className="text-sm text-primary">{description}</p>}
         <DataTable isLoading={isLoading} data={contracts} columns={cols} />
       </div>
     </section>

--- a/services/explorer-ui/src/pages/contract-class-details/index.tsx
+++ b/services/explorer-ui/src/pages/contract-class-details/index.tsx
@@ -3,7 +3,12 @@ import { type FC } from "react";
 import { KeyValueDisplay } from "~/components/info-display/key-value-display";
 import { Loader } from "~/components/loader";
 import { OrphanedBanner } from "~/components/orphaned-banner";
-import { useContractClass, useContractClasses, useSubTitle } from "~/hooks";
+import {
+  useContractClass,
+  useContractClasses,
+  useDeployedContractInstances,
+  useSubTitle,
+} from "~/hooks";
 import { TabSection } from "./tabs-section";
 import { getContractClassKeyValueData } from "./util";
 
@@ -14,7 +19,7 @@ export const ContractClassDetails: FC = () => {
   useSubTitle(`Address ${id}`);
 
   const contractClassesRes = useContractClasses(id);
-
+  const contractInstances = useDeployedContractInstances(id);
   const selectedVersionWithArtifactRes = useContractClass({
     classId: id,
     version: version,
@@ -27,7 +32,6 @@ export const ContractClassDetails: FC = () => {
   if (!version) {
     return <div>No version provided</div>;
   }
-
   const selectedVersion = selectedVersionWithArtifactRes?.data
     ? selectedVersionWithArtifactRes.data
     : contractClassesRes.data?.find(
@@ -58,7 +62,10 @@ export const ContractClassDetails: FC = () => {
           {contractClassesRes.error && <div>error</div>}
           {selectedVersion && (
             <KeyValueDisplay
-              data={getContractClassKeyValueData(selectedVersion)}
+              data={getContractClassKeyValueData(
+                selectedVersion,
+                contractInstances.data,
+              )}
             />
           )}
         </div>
@@ -66,7 +73,7 @@ export const ContractClassDetails: FC = () => {
       <div className="mt-5">
         <TabSection
           contractClasses={contractClassesRes}
-          contractClassId={id}
+          contractInstances={contractInstances}
           selectedVersion={selectedVersion}
           isContractArtifactLoading={selectedVersionWithArtifactRes.isLoading}
           contractArtifactError={selectedVersionWithArtifactRes.error}

--- a/services/explorer-ui/src/pages/contract-class-details/key-value-helpers.ts
+++ b/services/explorer-ui/src/pages/contract-class-details/key-value-helpers.ts
@@ -1,9 +1,14 @@
-import { ContractType, type ChicmozL2ContractClassRegisteredEvent } from "@chicmoz-pkg/types";
+import {
+  type ChicmozL2ContractInstanceDeluxe,
+  ContractType,
+  type ChicmozL2ContractClassRegisteredEvent,
+} from "@chicmoz-pkg/types";
 import { routes } from "~/routes/__root";
 import { API_URL, aztecExplorer } from "~/service/constants";
 
 export const getContractClassKeyValueData = (
   data: ChicmozL2ContractClassRegisteredEvent,
+  instanceData?: ChicmozL2ContractInstanceDeluxe[],
 ) => {
   return [
     {
@@ -38,6 +43,10 @@ export const getContractClassKeyValueData = (
     {
       label: "CONTRACT TYPE",
       value: data.contractType ?? ContractType.Unknown,
+    },
+    {
+      label: "INSTANCES DEPLOYED",
+      value: instanceData ? String(instanceData.length) : undefined,
     },
   ];
 };

--- a/services/explorer-ui/src/pages/contract-class-details/tabs-section.tsx
+++ b/services/explorer-ui/src/pages/contract-class-details/tabs-section.tsx
@@ -1,9 +1,11 @@
-import { type ChicmozL2ContractClassRegisteredEvent } from "@chicmoz-pkg/types";
+import {
+  type ChicmozL2ContractInstanceDeluxe,
+  type ChicmozL2ContractClassRegisteredEvent,
+} from "@chicmoz-pkg/types";
 import { type UseQueryResult } from "@tanstack/react-query";
 import { useState, type FC } from "react";
 import { Loader } from "~/components/loader";
 import { OptionButtons } from "~/components/option-buttons";
-import { useDeployedContractInstances } from "~/hooks";
 import { contractClassTabs, type TabId } from "./constants";
 import { getDataFromMap } from "./display-utils";
 import { ArtifactExplorerTab } from "./tabs/artifact-explorer-tab";
@@ -21,7 +23,7 @@ interface TabSectionProps {
     ChicmozL2ContractClassRegisteredEvent[],
     Error
   >;
-  contractClassId: string;
+  contractInstances: UseQueryResult<ChicmozL2ContractInstanceDeluxe[], Error>;
   selectedVersion: ChicmozL2ContractClassRegisteredEvent | undefined;
   isContractArtifactLoading: boolean;
   contractArtifactError: Error | null;
@@ -29,12 +31,11 @@ interface TabSectionProps {
 
 export const TabSection: FC<TabSectionProps> = ({
   contractClasses,
-  contractClassId,
+  contractInstances,
   selectedVersion,
   isContractArtifactLoading,
 }) => {
   const [selectedTab, setSelectedTab] = useState<TabId>("contractVersions");
-  const contractInstances = useDeployedContractInstances(contractClassId);
   const onOptionSelect = (value: string) => {
     setSelectedTab(value as TabId);
   };

--- a/services/explorer-ui/src/pages/contract-class-details/tabs/contract-instances.tsx
+++ b/services/explorer-ui/src/pages/contract-class-details/tabs/contract-instances.tsx
@@ -13,9 +13,11 @@ export const ContractInstancesTab: FC<ContractInstancesProps> = ({ data }) => {
     isLoading: isLoadingInstances,
     error: errorInstances,
   } = data;
+  const description = `Total amount of instances: ${instancesData?.length}`;
   return (
     <ContractInstancesTable
       title="Latest Contract Instances"
+      description={description}
       contracts={mapContractInstances(instancesData)}
       isLoading={isLoadingInstances}
       error={errorInstances}

--- a/services/explorer-ui/src/pages/contract-class-details/tabs/contract-instances.tsx
+++ b/services/explorer-ui/src/pages/contract-class-details/tabs/contract-instances.tsx
@@ -13,11 +13,9 @@ export const ContractInstancesTab: FC<ContractInstancesProps> = ({ data }) => {
     isLoading: isLoadingInstances,
     error: errorInstances,
   } = data;
-  const description = `Total amount of instances: ${instancesData?.length}`;
   return (
     <ContractInstancesTable
       title="Latest Contract Instances"
-      description={description}
       contracts={mapContractInstances(instancesData)}
       isLoading={isLoadingInstances}
       error={errorInstances}


### PR DESCRIPTION
Adding the total amount of instances of a contract Class to `contract class detail page` 