### PR TITLE
bug: using `getDefaultInitializer`-function from Aztec

### DIFF
--- a/packages/contract-verification/src/instance-deployment/verify-payload.ts
+++ b/packages/contract-verification/src/instance-deployment/verify-payload.ts
@@ -5,6 +5,7 @@ import {
   PublicKeys,
   loadContractArtifact,
 } from "@aztec/aztec.js";
+import { getDefaultInitializer } from "@aztec/stdlib/abi";
 import {
   computeContractAddressFromInstance,
   computeInitializationHash,
@@ -31,7 +32,7 @@ export const verifyInstanceDeploymentPayload = async (
     JSON.parse(stringifiedArtifactJson) as unknown as NoirCompiledContract,
   );
 
-  const initFn = artifact.functions.find((fn) => fn.name === "constructor");
+  const initFn = getDefaultInitializer(artifact);
   const initializationHash = await computeInitializationHash(
     initFn,
     constructorArgs,


### PR DESCRIPTION
resolves #495 