### PR TITLE
feat: Add endpoint to get all contract instances with balance

### DIFF
--- a/services/explorer-api/src/svcs/database/controllers/contract-instance-balance/get-balance.ts
+++ b/services/explorer-api/src/svcs/database/controllers/contract-instance-balance/get-balance.ts
@@ -4,7 +4,7 @@ import {
   chicmozContractInstanceBalanceSchema,
   HexString,
 } from "@chicmoz-pkg/types";
-import { desc, eq } from "drizzle-orm";
+import { desc, eq, gt } from "drizzle-orm";
 import { contractInstanceBalance } from "../../schema/contract-instance-balance/index.js";
 
 export const getLatestContractInstanceBalance = async (
@@ -22,4 +22,19 @@ export const getLatestContractInstanceBalance = async (
   }
 
   return chicmozContractInstanceBalanceSchema.parse(result[0]);
+};
+
+export const getCotractIstacesWithBalance = async (): Promise<
+  ChicmozContractInstanceBalance[]
+> => {
+  const result = await db()
+    .selectDistinctOn([contractInstanceBalance.contractAddress])
+    .from(contractInstanceBalance)
+    .orderBy(
+      contractInstanceBalance.contractAddress,
+      desc(contractInstanceBalance.timestamp),
+    )
+    .where(gt(contractInstanceBalance.balance, "0"));
+
+  return result.map((row) => chicmozContractInstanceBalanceSchema.parse(row));
 };

--- a/services/explorer-api/src/svcs/http-server/routes/controllers/contract-instance-balance.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/controllers/contract-instance-balance.ts
@@ -1,12 +1,15 @@
 import asyncHandler from "express-async-handler";
 import { OpenAPIObject } from "openapi3-ts/oas31";
-import { getLatestContractInstanceBalance } from "../../../database/controllers/contract-instance-balance/index.js";
+import {
+  getLatestContractInstanceBalance,
+  getCotractIstacesWithBalance,
+} from "../../../database/controllers/contract-instance-balance/index.js";
 import { getContractInstanceBalanceSchema } from "../paths_and_validation.js";
 import { contractInstanceBalanceResponse, dbWrapper } from "./utils/index.js";
 
 export const openapi_GET_L2_CONTRACT_INSTANCE_BALANCE: OpenAPIObject["paths"] =
   {
-    "/l2/contract-instance/{address}/balance": {
+    "/l2/contract-instances/{address}/balance": {
       get: {
         tags: ["L2", "contract-instances"],
         summary: "Get contract instance balance by address",
@@ -34,6 +37,31 @@ export const openapi_GET_L2_CONTRACT_INSTANCE_BALANCE: OpenAPIObject["paths"] =
     },
   };
 
+export const openapi_GET_L2_CONTRACT_INSTANCES_WITH_BALANCE: OpenAPIObject["paths"] =
+  {
+    "/l2/contract-instances/with-balance": {
+      get: {
+        tags: ["L2", "contract-instances"],
+        summary: "Get all contract instances with balance",
+        responses: {
+          "200": {
+            description: "List of contract instances with balance",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: {
+                    $ref: "#/components/schemas/ChicmozContractInstanceBalance",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
 export const GET_L2_CONTRACT_INSTANCE_BALANCE = asyncHandler(
   async (req, res) => {
     const {
@@ -43,6 +71,16 @@ export const GET_L2_CONTRACT_INSTANCE_BALANCE = asyncHandler(
     const balanceData = await dbWrapper.get(
       ["l2", "contract-instance", address, "balance"],
       () => getLatestContractInstanceBalance(address),
+    );
+    res.status(200).json(JSON.parse(balanceData));
+  },
+);
+
+export const GET_L2_CONTRACT_INSTANCES_WITH_BALANCE = asyncHandler(
+  async (req, res) => {
+    const balanceData = await dbWrapper.get(
+      ["l2", "contract-instances", "with-balance"],
+      () => getCotractIstacesWithBalance(),
     );
     res.status(200).json(JSON.parse(balanceData));
   },

--- a/services/explorer-api/src/svcs/http-server/routes/index.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/index.ts
@@ -44,6 +44,7 @@ export const openApiPaths: OpenAPIObject["paths"] = {
   ...controller.openapi_GET_L2_CONTRACT_INSTANCES_BY_CONTRACT_CLASS_ID,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCE,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCE_BALANCE,
+  ...controller.openapi_GET_L2_CONTRACT_INSTANCES_WITH_BALANCE,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCES,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCES_WITH_AZTEC_SCAN_NOTES,
   ...controller.openapi_POST_L2_VERIFY_CONTRACT_INSTANCE_DEPLOYMENT,
@@ -217,6 +218,10 @@ export const init = ({ router }: { router: Router }) => {
   router.get(
     paths.contractInstancesWithAztecScanNotes,
     controller.GET_L2_CONTRACT_INSTANCES_WITH_AZTEC_SCAN_NOTES,
+  );
+  router.get(
+    paths.contractInstancesWithBalance,
+    controller.GET_L2_CONTRACT_INSTANCES_WITH_BALANCE,
   );
   router.get(paths.contractInstance, controller.GET_L2_CONTRACT_INSTANCE);
   router.get(

--- a/services/explorer-api/src/svcs/http-server/routes/paths_and_validation.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/paths_and_validation.ts
@@ -62,6 +62,7 @@ export const paths = {
     "/l2/contract-instances/with-aztec-scan-notes",
   contractInstance: `/l2/contract-instances/:${address}`,
   contractInstanceBalance: `/l2/contract-instances/:${address}/balance`,
+  contractInstancesWithBalance: "/l2/contract-instances/with-balance",
   contractInstances: "/l2/contract-instances",
 
   search: "/l2/search",

--- a/services/explorer-ui/src/api/contract.ts
+++ b/services/explorer-ui/src/api/contract.ts
@@ -1,9 +1,11 @@
 import {
   aztecScanNoteSchema,
+  chicmozContractInstanceBalanceSchema,
   chicmozL2ContractClassRegisteredEventSchema,
   chicmozL2ContractInstanceDeluxeSchema,
   chicmozL2PrivateFunctionBroadcastedEventSchema,
   chicmozL2UtilityFunctionBroadcastedEventSchema,
+  type ChicmozContractInstanceBalance,
   type ChicmozL2ContractClassRegisteredEvent,
   type ChicmozL2ContractInstanceDeluxe,
   type ChicmozL2PrivateFunctionBroadcastedEvent,
@@ -116,6 +118,17 @@ export const ContractL2API = {
     );
     return validateResponse(
       contractInstancesWithAztecScanNotesSchema.array(),
+      response.data,
+    );
+  },
+  getContractInstancesWithBalance: async (): Promise<
+    ChicmozContractInstanceBalance[]
+  > => {
+    const response = await client.get(
+      aztecExplorer.getL2ContractInstancesWithBalance,
+    );
+    return validateResponse(
+      chicmozContractInstanceBalanceSchema.array(),
       response.data,
     );
   },

--- a/services/explorer-ui/src/hooks/api/contract.ts
+++ b/services/explorer-ui/src/hooks/api/contract.ts
@@ -1,4 +1,5 @@
 import {
+  type ChicmozContractInstanceBalance,
   type ChicmozL2ContractClassRegisteredEvent,
   type ChicmozL2ContractInstanceDeluxe,
   type ChicmozL2PrivateFunctionBroadcastedEvent,
@@ -93,6 +94,16 @@ export const useContractInstancesWithAztecScanNotes = (): UseQueryResult<
   return useQuery<ChicmozL2ContractInstanceWithAztecScanNotes[], Error>({
     queryKey: queryKeyGenerator.contractInstancesWithAztecScanNotes,
     queryFn: () => ContractL2API.getContractInstancesWithAztecScanNotes(),
+  });
+};
+
+export const useContractInstancesWithBalance = (): UseQueryResult<
+  ChicmozContractInstanceBalance[],
+  Error
+> => {
+  return useQuery<ChicmozContractInstanceBalance[], Error>({
+    queryKey: queryKeyGenerator.contractInstancesWithBalance,
+    queryFn: () => ContractL2API.getContractInstancesWithBalance(),
   });
 };
 

--- a/services/explorer-ui/src/hooks/api/utils.ts
+++ b/services/explorer-ui/src/hooks/api/utils.ts
@@ -55,6 +55,7 @@ export const queryKeyGenerator = {
   contractInstance: (address: string) => ["contractInstance", address],
   latestContractInstances: ["latestContractInstances"],
   contractInstancesWithAztecScanNotes: ["contractInstancesWithAztecScanNotes"],
+  contractInstancesWithBalance: ["contractInstancesWithBalance"],
   deployedContractInstances: (classId: string) => [
     "deployedContractInstances",
     classId,

--- a/services/explorer-ui/src/pages/dev.tsx
+++ b/services/explorer-ui/src/pages/dev.tsx
@@ -4,6 +4,7 @@ import { type FC } from "react";
 import {
   useChainErrors,
   useChainInfo,
+  useContractInstancesWithBalance,
   useSequencers,
   useSubTitle,
 } from "~/hooks";
@@ -36,6 +37,12 @@ export const DevPage: FC = () => {
     isLoading: isSequencersLoading,
     error: sequencersError,
   } = useSequencers();
+
+  const {
+    data: contractInstancesWithBalance,
+    isLoading: isContractInstancesWithBalanceLoading,
+    error: contractInstancesWithBalanceError,
+  } = useContractInstancesWithBalance();
 
   const generateCard = (title: string, content: string | JSX.Element) => (
     <div className="bg-white w-full rounded-lg shadow-md p-4 md:w-[80%] mt-4">
@@ -162,6 +169,36 @@ stack:          ${error.stack}
                 2,
               )}
             </pre>
+          )}
+        </>,
+      )}
+      {generateCard(
+        "Instances with balance",
+        <>
+          {isContractInstancesWithBalanceLoading && <p>Loading...</p>}
+          {contractInstancesWithBalanceError && (
+            <p>Error: {contractInstancesWithBalanceError.message}</p>
+          )}
+          {contractInstancesWithBalance && (
+            <div>
+              <p>
+                Found {contractInstancesWithBalance.length} contract instances
+                with balance
+              </p>
+              {contractInstancesWithBalance.length > 0 && (
+                <pre>
+                  {JSON.stringify(
+                    contractInstancesWithBalance.map((instance) => ({
+                      contractAddress: instance.contractAddress,
+                      balance: Number(instance.balance),
+                      timestamp: instance.timestamp,
+                    })),
+                    null,
+                    2,
+                  )}
+                </pre>
+              )}
+            </div>
           )}
         </>,
       )}

--- a/services/explorer-ui/src/service/constants.ts
+++ b/services/explorer-ui/src/service/constants.ts
@@ -42,6 +42,7 @@ export const aztecExplorer = {
   getL2ContractInstance: (address: string) =>
     `/l2/contract-instances/${address}`,
   getL2ContractInstances: "/l2/contract-instances",
+  getL2ContractInstancesWithBalance: "/l2/contract-instances/with-balance",
   getAmountContractClassInstances: (classId: string) =>
     `/l2/stats/total-contract-instances/${classId}`,
   getL2ContractInstancesWithAztecScanNotes:


### PR DESCRIPTION
## Summary
Add new API endpoint to get all contract instances with balance and display them on dev page.

## Changes
- Backend: Added  endpoint
- Frontend: Added API client, hook, and UI display on dev page