### PR TITLE
feat: Add fee juice balance display to contract instance details

### DIFF
--- a/services/explorer-api/src/svcs/database/controllers/contract-instance-balance/get-balance.ts
+++ b/services/explorer-api/src/svcs/database/controllers/contract-instance-balance/get-balance.ts
@@ -4,7 +4,7 @@ import {
   chicmozContractInstanceBalanceSchema,
   HexString,
 } from "@chicmoz-pkg/types";
-import { desc, eq } from "drizzle-orm";
+import { desc, eq, gt } from "drizzle-orm";
 import { contractInstanceBalance } from "../../schema/contract-instance-balance/index.js";
 
 export const getLatestContractInstanceBalance = async (
@@ -22,4 +22,19 @@ export const getLatestContractInstanceBalance = async (
   }
 
   return chicmozContractInstanceBalanceSchema.parse(result[0]);
+};
+
+export const getCotractIstacesWithBalance = async (): Promise<
+  ChicmozContractInstanceBalance[]
+> => {
+  const result = await db()
+    .selectDistinctOn([contractInstanceBalance.contractAddress])
+    .from(contractInstanceBalance)
+    .orderBy(
+      contractInstanceBalance.contractAddress,
+      desc(contractInstanceBalance.timestamp),
+    )
+    .where(gt(contractInstanceBalance.balance, "0"));
+
+  return result.map((row) => chicmozContractInstanceBalanceSchema.parse(row));
 };

--- a/services/explorer-api/src/svcs/http-server/routes/controllers/contract-instance-balance.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/controllers/contract-instance-balance.ts
@@ -1,12 +1,15 @@
 import asyncHandler from "express-async-handler";
 import { OpenAPIObject } from "openapi3-ts/oas31";
-import { getLatestContractInstanceBalance } from "../../../database/controllers/contract-instance-balance/index.js";
+import {
+  getLatestContractInstanceBalance,
+  getCotractIstacesWithBalance,
+} from "../../../database/controllers/contract-instance-balance/index.js";
 import { getContractInstanceBalanceSchema } from "../paths_and_validation.js";
 import { contractInstanceBalanceResponse, dbWrapper } from "./utils/index.js";
 
 export const openapi_GET_L2_CONTRACT_INSTANCE_BALANCE: OpenAPIObject["paths"] =
   {
-    "/l2/contract-instance/{address}/balance": {
+    "/l2/contract-instances/{address}/balance": {
       get: {
         tags: ["L2", "contract-instances"],
         summary: "Get contract instance balance by address",
@@ -34,6 +37,31 @@ export const openapi_GET_L2_CONTRACT_INSTANCE_BALANCE: OpenAPIObject["paths"] =
     },
   };
 
+export const openapi_GET_L2_CONTRACT_INSTANCES_WITH_BALANCE: OpenAPIObject["paths"] =
+  {
+    "/l2/contract-instances/with-balance": {
+      get: {
+        tags: ["L2", "contract-instances"],
+        summary: "Get all contract instances with balance",
+        responses: {
+          "200": {
+            description: "List of contract instances with balance",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: {
+                    $ref: "#/components/schemas/ChicmozContractInstanceBalance",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
 export const GET_L2_CONTRACT_INSTANCE_BALANCE = asyncHandler(
   async (req, res) => {
     const {
@@ -43,6 +71,16 @@ export const GET_L2_CONTRACT_INSTANCE_BALANCE = asyncHandler(
     const balanceData = await dbWrapper.get(
       ["l2", "contract-instance", address, "balance"],
       () => getLatestContractInstanceBalance(address),
+    );
+    res.status(200).json(JSON.parse(balanceData));
+  },
+);
+
+export const GET_L2_CONTRACT_INSTANCES_WITH_BALANCE = asyncHandler(
+  async (req, res) => {
+    const balanceData = await dbWrapper.get(
+      ["l2", "contract-instances", "with-balance"],
+      () => getCotractIstacesWithBalance(),
     );
     res.status(200).json(JSON.parse(balanceData));
   },

--- a/services/explorer-api/src/svcs/http-server/routes/index.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/index.ts
@@ -44,6 +44,7 @@ export const openApiPaths: OpenAPIObject["paths"] = {
   ...controller.openapi_GET_L2_CONTRACT_INSTANCES_BY_CONTRACT_CLASS_ID,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCE,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCE_BALANCE,
+  ...controller.openapi_GET_L2_CONTRACT_INSTANCES_WITH_BALANCE,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCES,
   ...controller.openapi_GET_L2_CONTRACT_INSTANCES_WITH_AZTEC_SCAN_NOTES,
   ...controller.openapi_POST_L2_VERIFY_CONTRACT_INSTANCE_DEPLOYMENT,
@@ -217,6 +218,10 @@ export const init = ({ router }: { router: Router }) => {
   router.get(
     paths.contractInstancesWithAztecScanNotes,
     controller.GET_L2_CONTRACT_INSTANCES_WITH_AZTEC_SCAN_NOTES,
+  );
+  router.get(
+    paths.contractInstancesWithBalance,
+    controller.GET_L2_CONTRACT_INSTANCES_WITH_BALANCE,
   );
   router.get(paths.contractInstance, controller.GET_L2_CONTRACT_INSTANCE);
   router.get(

--- a/services/explorer-api/src/svcs/http-server/routes/paths_and_validation.ts
+++ b/services/explorer-api/src/svcs/http-server/routes/paths_and_validation.ts
@@ -62,6 +62,7 @@ export const paths = {
     "/l2/contract-instances/with-aztec-scan-notes",
   contractInstance: `/l2/contract-instances/:${address}`,
   contractInstanceBalance: `/l2/contract-instances/:${address}/balance`,
+  contractInstancesWithBalance: "/l2/contract-instances/with-balance",
   contractInstances: "/l2/contract-instances",
 
   search: "/l2/search",

--- a/services/explorer-ui/src/api/contract.ts
+++ b/services/explorer-ui/src/api/contract.ts
@@ -101,6 +101,17 @@ export const ContractL2API = {
       response.data,
     );
   },
+  getContractInstanceBalance: async (
+    address: string,
+  ): Promise<ChicmozContractInstanceBalance> => {
+    const response = await client.get(
+      aztecExplorer.getL2ContractInstanceBalance(address),
+    );
+    return validateResponse(
+      chicmozContractInstanceBalanceSchema,
+      response.data,
+    );
+  },
   getContractInstances: async (): Promise<
     ChicmozL2ContractInstanceDeluxe[]
   > => {

--- a/services/explorer-ui/src/api/contract.ts
+++ b/services/explorer-ui/src/api/contract.ts
@@ -1,9 +1,11 @@
 import {
   aztecScanNoteSchema,
+  chicmozContractInstanceBalanceSchema,
   chicmozL2ContractClassRegisteredEventSchema,
   chicmozL2ContractInstanceDeluxeSchema,
   chicmozL2PrivateFunctionBroadcastedEventSchema,
   chicmozL2UtilityFunctionBroadcastedEventSchema,
+  type ChicmozContractInstanceBalance,
   type ChicmozL2ContractClassRegisteredEvent,
   type ChicmozL2ContractInstanceDeluxe,
   type ChicmozL2PrivateFunctionBroadcastedEvent,
@@ -116,6 +118,17 @@ export const ContractL2API = {
     );
     return validateResponse(
       contractInstancesWithAztecScanNotesSchema.array(),
+      response.data,
+    );
+  },
+  getContractInstancesWithBalance: async (): Promise<
+    ChicmozContractInstanceBalance[]
+  > => {
+    const response = await client.get(
+      aztecExplorer.getL2ContractInstancesWithBalance,
+    );
+    return validateResponse(
+      chicmozContractInstanceBalanceSchema.array(),
       response.data,
     );
   },

--- a/services/explorer-ui/src/components/loading/util.ts
+++ b/services/explorer-ui/src/components/loading/util.ts
@@ -74,7 +74,7 @@ export const getEmptyBlockData = (hash?: string, timestamp?: number) => [
     value: undefined,
   },
 ];
-export const getEmptyContractIstanceData = () => [
+export const getEmptyContractInstanceData = () => [
   {
     label: "ADDRESS",
     value: undefined,

--- a/services/explorer-ui/src/components/loading/util.ts
+++ b/services/explorer-ui/src/components/loading/util.ts
@@ -74,3 +74,27 @@ export const getEmptyBlockData = (hash?: string, timestamp?: number) => [
     value: undefined,
   },
 ];
+export const getEmptyContractIstanceData = () => [
+  {
+    label: "ADDRESS",
+    value: undefined,
+  },
+  {
+    label: "CLASS ID",
+    value: undefined,
+  },
+  {
+    label: "BLOCK HASH",
+    value: undefined,
+  },
+  { label: "VERSION", value: undefined },
+  { label: "DEPLOYER", value: undefined },
+  {
+    label: "FEE JUICE BALANCE",
+    value: undefined,
+  },
+  {
+    label: "RAW DATA",
+    value: undefined,
+  },
+];

--- a/services/explorer-ui/src/hooks/api/contract.ts
+++ b/services/explorer-ui/src/hooks/api/contract.ts
@@ -1,4 +1,5 @@
 import {
+  type ChicmozContractInstanceBalance,
   type ChicmozL2ContractClassRegisteredEvent,
   type ChicmozL2ContractInstanceDeluxe,
   type ChicmozL2PrivateFunctionBroadcastedEvent,
@@ -93,6 +94,16 @@ export const useContractInstancesWithAztecScanNotes = (): UseQueryResult<
   return useQuery<ChicmozL2ContractInstanceWithAztecScanNotes[], Error>({
     queryKey: queryKeyGenerator.contractInstancesWithAztecScanNotes,
     queryFn: () => ContractL2API.getContractInstancesWithAztecScanNotes(),
+  });
+};
+
+export const useContractInstancesWithBalance = (): UseQueryResult<
+  ChicmozContractInstanceBalance[],
+  Error
+> => {
+  return useQuery<ChicmozContractInstanceBalance[], Error>({
+    queryKey: queryKeyGenerator.contractInstancesWithBalance,
+    queryFn: () => ContractL2API.getContractInstancesWithBalance(),
   });
 };
 

--- a/services/explorer-ui/src/hooks/api/contract.ts
+++ b/services/explorer-ui/src/hooks/api/contract.ts
@@ -77,6 +77,15 @@ export const useContractInstance = (
   });
 };
 
+export const useContractInstanceBalance = (
+  address: string,
+): UseQueryResult<ChicmozContractInstanceBalance, Error> => {
+  return useQuery<ChicmozContractInstanceBalance, Error>({
+    queryKey: queryKeyGenerator.contractInstanceBalance(address),
+    queryFn: () => ContractL2API.getContractInstanceBalance(address),
+  });
+};
+
 export const useLatestContractInstances = (): UseQueryResult<
   ChicmozL2ContractInstanceDeluxe[],
   Error

--- a/services/explorer-ui/src/hooks/api/utils.ts
+++ b/services/explorer-ui/src/hooks/api/utils.ts
@@ -55,6 +55,7 @@ export const queryKeyGenerator = {
   contractInstance: (address: string) => ["contractInstance", address],
   latestContractInstances: ["latestContractInstances"],
   contractInstancesWithAztecScanNotes: ["contractInstancesWithAztecScanNotes"],
+  contractInstancesWithBalance: ["contractInstancesWithBalance"],
   deployedContractInstances: (classId: string) => [
     "deployedContractInstances",
     classId,

--- a/services/explorer-ui/src/hooks/api/utils.ts
+++ b/services/explorer-ui/src/hooks/api/utils.ts
@@ -53,6 +53,7 @@ export const queryKeyGenerator = {
     classId,
   ],
   contractInstance: (address: string) => ["contractInstance", address],
+  contractInstanceBalance: (address: string) => ["contractInstanceBalance", address],
   latestContractInstances: ["latestContractInstances"],
   contractInstancesWithAztecScanNotes: ["contractInstancesWithAztecScanNotes"],
   contractInstancesWithBalance: ["contractInstancesWithBalance"],

--- a/services/explorer-ui/src/pages/contract-instance-details/index.tsx
+++ b/services/explorer-ui/src/pages/contract-instance-details/index.tsx
@@ -13,7 +13,7 @@ import {
   getVerifiedContractInstanceDeploymentData,
 } from "./util";
 import { LoadingDetails } from "~/components/loading/loading-details";
-import { getEmptyContractIstanceData } from "~/components/loading/util";
+import { getEmptyContractInstanceData } from "~/components/loading/util";
 
 export const ContractInstanceDetails: FC = () => {
   const { address } = useParams({
@@ -40,7 +40,7 @@ export const ContractInstanceDetails: FC = () => {
     return (
       <LoadingDetails
         title="Loading Contract instances details"
-        emptyData={getEmptyContractIstanceData()}
+        emptyData={getEmptyContractInstanceData()}
       />
     );
   }

--- a/services/explorer-ui/src/pages/contract-instance-details/index.tsx
+++ b/services/explorer-ui/src/pages/contract-instance-details/index.tsx
@@ -2,12 +2,18 @@ import { useParams } from "@tanstack/react-router";
 import { type FC } from "react";
 import { KeyValueDisplay } from "~/components/info-display/key-value-display";
 import { OrphanedBanner } from "~/components/orphaned-banner";
-import { useContractInstance, useSubTitle } from "~/hooks";
+import {
+  useContractInstance,
+  useContractInstanceBalance,
+  useSubTitle,
+} from "~/hooks";
 import { TabsSection } from "./tabs-section";
 import {
   getContractData,
   getVerifiedContractInstanceDeploymentData,
 } from "./util";
+import { LoadingDetails } from "~/components/loading/loading-details";
+import { getEmptyContractIstanceData } from "~/components/loading/util";
 
 export const ContractInstanceDetails: FC = () => {
   const { address } = useParams({
@@ -20,17 +26,37 @@ export const ContractInstanceDetails: FC = () => {
     error,
   } = useContractInstance(address);
 
+  const { data: contractInstanceBalance } = useContractInstanceBalance(address);
+
   if (!address) {
-    return <div>No contract address</div>;
+    return (
+      <LoadingDetails
+        title="No Contract instance address provided"
+        description={"Please provided a correct hash"}
+      />
+    );
   }
   if (isLoading) {
-    return <div>Loading...</div>;
+    return (
+      <LoadingDetails
+        title="Loading Contract instances details"
+        emptyData={getEmptyContractIstanceData()}
+      />
+    );
   }
   if (error) {
-    return <div>Error</div>;
+    <LoadingDetails
+      title="Error fetching the contract-instance details"
+      description={"Please try to reload the page"}
+    />;
   }
   if (!contractInstanceDetails) {
-    return <div>No data</div>;
+    return (
+      <LoadingDetails
+        title="No Contract instance found"
+        description={`Please check if the cotract instance address: ${address} is correct`}
+      />
+    );
   }
 
   const { verifiedDeploymentArguments, deployerMetadata, aztecScanNotes } =
@@ -53,21 +79,22 @@ export const ContractInstanceDetails: FC = () => {
             <OrphanedBanner type="contract-instance" />
           ) : null}
           <div className="bg-white rounded-lg shadow-md p-4">
-            <KeyValueDisplay data={getContractData(contractInstanceDetails)} />
+            <KeyValueDisplay
+              data={getContractData(
+                contractInstanceDetails,
+                contractInstanceBalance,
+              )}
+            />
           </div>
         </div>
       </div>
-      {verifiedDeploymentArguments?.length ??
-      deployerMetadata?.length ??
-      aztecScanNotes?.length ? (
-        <div className="mt-5">
-          <TabsSection
-            verifiedDeploymentData={verifiedDeploymentArguments}
-            deployerMetadata={deployerMetadata}
-            aztecScanNotes={aztecScanNotes}
-          />
-        </div>
-      ) : null}
+      <div className="mt-5">
+        <TabsSection
+          verifiedDeploymentData={verifiedDeploymentArguments}
+          deployerMetadata={deployerMetadata}
+          aztecScanNotes={aztecScanNotes}
+        />
+      </div>
     </div>
   );
 };

--- a/services/explorer-ui/src/pages/contract-instance-details/util.ts
+++ b/services/explorer-ui/src/pages/contract-instance-details/util.ts
@@ -1,11 +1,17 @@
-import { type ChicmozL2ContractInstanceDeluxe } from "@chicmoz-pkg/types";
+import {
+  type ChicmozContractInstanceBalance,
+  type ChicmozL2ContractInstanceDeluxe,
+} from "@chicmoz-pkg/types";
 import { routes } from "~/routes/__root";
 import { API_URL, aztecExplorer } from "~/service/constants";
 
 const HARDCODED_DEPLOYER =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
 
-export const getContractData = (data: ChicmozL2ContractInstanceDeluxe) => {
+export const getContractData = (
+  data: ChicmozL2ContractInstanceDeluxe,
+  balance?: ChicmozContractInstanceBalance,
+) => {
   const link = `${routes.contracts.route}${routes.contracts.children.classes.route}/${data.contractClassId}/versions/${data.version}`;
   const displayData = [
     {
@@ -25,11 +31,13 @@ export const getContractData = (data: ChicmozL2ContractInstanceDeluxe) => {
     { label: "VERSION", value: data.version.toString(), link },
     { label: "DEPLOYER", value: data.deployer },
     {
+      label: "FEE JUICE BALANCE",
+      value: !balance ? "0" : balance.balance.toString(),
+    },
+    {
       label: "RAW DATA",
       value: "View raw data",
-      extLink: `${API_URL}${aztecExplorer.getL2ContractInstance(
-        data.address,
-      )}`,
+      extLink: `${API_URL}${aztecExplorer.getL2ContractInstance(data.address)}`,
     },
   ];
   const isDeployerContract =
@@ -103,7 +111,8 @@ export const getVerifiedContractInstanceDeploymentData = (
         },
         {
           label: "CONSTRUCTOR ARGS",
-          value: data.verifiedDeploymentArguments.constructorArgs.join(", ") ?? "[]",
+          value:
+            data.verifiedDeploymentArguments.constructorArgs.join(", ") ?? "[]",
         },
       ]
     : undefined;

--- a/services/explorer-ui/src/pages/dev.tsx
+++ b/services/explorer-ui/src/pages/dev.tsx
@@ -4,6 +4,7 @@ import { type FC } from "react";
 import {
   useChainErrors,
   useChainInfo,
+  useContractInstancesWithBalance,
   useSequencers,
   useSubTitle,
 } from "~/hooks";
@@ -36,6 +37,12 @@ export const DevPage: FC = () => {
     isLoading: isSequencersLoading,
     error: sequencersError,
   } = useSequencers();
+
+  const {
+    data: contractInstancesWithBalance,
+    isLoading: isContractInstancesWithBalanceLoading,
+    error: contractInstancesWithBalanceError,
+  } = useContractInstancesWithBalance();
 
   const generateCard = (title: string, content: string | JSX.Element) => (
     <div className="bg-white w-full rounded-lg shadow-md p-4 md:w-[80%] mt-4">
@@ -162,6 +169,36 @@ stack:          ${error.stack}
                 2,
               )}
             </pre>
+          )}
+        </>,
+      )}
+      {generateCard(
+        "Instances with balance",
+        <>
+          {isContractInstancesWithBalanceLoading && <p>Loading...</p>}
+          {contractInstancesWithBalanceError && (
+            <p>Error: {contractInstancesWithBalanceError.message}</p>
+          )}
+          {contractInstancesWithBalance && (
+            <div>
+              <p>
+                Found {contractInstancesWithBalance.length} contract instances
+                with balance
+              </p>
+              {contractInstancesWithBalance.length > 0 && (
+                <pre>
+                  {JSON.stringify(
+                    contractInstancesWithBalance.map((instance) => ({
+                      contractAddress: instance.contractAddress,
+                      balance: Number(instance.balance),
+                      timestamp: instance.timestamp,
+                    })),
+                    null,
+                    2,
+                  )}
+                </pre>
+              )}
+            </div>
           )}
         </>,
       )}

--- a/services/explorer-ui/src/service/constants.ts
+++ b/services/explorer-ui/src/service/constants.ts
@@ -41,6 +41,8 @@ export const aztecExplorer = {
       : `/l2/contract-classes/${classId}/utility-functions`,
   getL2ContractInstance: (address: string) =>
     `/l2/contract-instances/${address}`,
+  getL2ContractInstanceBalance: (address: string) =>
+    `/l2/contract-instances/${address}/balance`,
   getL2ContractInstances: "/l2/contract-instances",
   getL2ContractInstancesWithBalance: "/l2/contract-instances/with-balance",
   getAmountContractClassInstances: (classId: string) =>

--- a/services/explorer-ui/src/service/constants.ts
+++ b/services/explorer-ui/src/service/constants.ts
@@ -42,6 +42,7 @@ export const aztecExplorer = {
   getL2ContractInstance: (address: string) =>
     `/l2/contract-instances/${address}`,
   getL2ContractInstances: "/l2/contract-instances",
+  getL2ContractInstancesWithBalance: "/l2/contract-instances/with-balance",
   getAmountContractClassInstances: (classId: string) =>
     `/l2/stats/total-contract-instances/${classId}`,
   getL2ContractInstancesWithAztecScanNotes:


### PR DESCRIPTION
## Summary
Add fee juice balance field to contract instance details page.

## Changes
- Frontend: Display fee juice balance in key-value pairs on contract instance details page
- Show balance or '0' if no balance found