### PR TITLE
ux: Add artifact tabs and contract standard type to contract instance details

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,7 +237,7 @@ src/components/
 
 ### PR Structure
 
-- the title of a PR has the following structure `<prefix>: <desctiption of the content>`
+- the title of a PR has the following structure `<prefix>: <description of the content>`
   `<prefix>` = either "bug", "hotfix", "feat", "ux"
 - do not write `generated with claude` in the descriptions.
-- for the pr descriprions please use a consise desctiption and make it short. just the key poits
+- for the PR descriptions please use a concise description and make it short. Just the key points.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,3 +232,12 @@ src/components/
 - Each service provides health endpoints
 - System health available at explorer-api `/health` endpoint
 - Database connection status tracked in `aztec-chain-connection` table
+
+## Git
+
+### PR Structure
+
+- the title of a PR has the following structure `<prefix>: <desctiption of the content>`
+  `<prefix>` = either "bug", "hotfix", "feat", "ux"
+- do not write `generated with claude` in the descriptions.
+- for the pr descriprions please use a consise desctiption and make it short. just the key poits

--- a/services/explorer-ui/src/components/option-buttons/index.tsx
+++ b/services/explorer-ui/src/components/option-buttons/index.tsx
@@ -28,7 +28,7 @@ type OptionButtonProps<T extends OptionItems> = {
 const withAvailableTooltip = (
   isAvailable: boolean,
   key: number,
-  children: React.ReactNode
+  children: React.ReactNode,
 ) => {
   // TODO: refactor to use CustomTooltip component instead?
   if (!isAvailable) {
@@ -48,6 +48,9 @@ export const OptionButtons = <T extends OptionItems>({
   onOptionSelect,
   selectedItem,
 }: OptionButtonProps<T>) => {
+  // Check if any options are available
+  const hasAnyAvailableOptions = Object.values(availableOptions).some(Boolean);
+  
   return (
     <>
       <div className="hidden lg:flex flex-row gap-4 mb-4 justify-center">
@@ -66,10 +69,10 @@ export const OptionButtons = <T extends OptionItems>({
               >
                 {option.label}
               </Button>
-              {selectedItem === option.id && (
+              {hasAnyAvailableOptions && selectedItem === option.id && (
                 <Separator className="h-0.5 bg-gray-700 w-1/2" />
               )}
-            </div>
+            </div>,
           );
         })}
       </div>
@@ -79,17 +82,15 @@ export const OptionButtons = <T extends OptionItems>({
             <SelectValue placeholder={selectedItem} />
           </SelectTrigger>
           <SelectContent>
-            {
-              options.map((option, key) => (
-                <SelectItem
-                  key={key}
-                  disabled={!availableOptions[option.id]}
-                  value={option.id}
-                >
-                  {option.label}
-                </SelectItem>
-              ))
-            }
+            {options.map((option, key) => (
+              <SelectItem
+                key={key}
+                disabled={!availableOptions[option.id]}
+                value={option.id}
+              >
+                {option.label}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </div>

--- a/services/explorer-ui/src/pages/contract-class-details/tabs-section.tsx
+++ b/services/explorer-ui/src/pages/contract-class-details/tabs-section.tsx
@@ -87,7 +87,7 @@ export const TabSection: FC<TabSectionProps> = ({
         ) : (
           <ArtifactJsonTab
             data={artifact}
-            artifactHash={selectedVersion?.artifactHash || ""}
+            artifactHash={selectedVersion?.artifactHash ?? ""}
           />
         );
       case "artifactExplorer":

--- a/services/explorer-ui/src/pages/contract-instance-details/index.tsx
+++ b/services/explorer-ui/src/pages/contract-instance-details/index.tsx
@@ -8,10 +8,7 @@ import {
   useSubTitle,
 } from "~/hooks";
 import { TabsSection } from "./tabs-section";
-import {
-  getContractData,
-  getVerifiedContractInstanceDeploymentData,
-} from "./util";
+import { getContractData } from "./util";
 import { LoadingDetails } from "~/components/loading/loading-details";
 import { getEmptyContractInstanceData } from "~/components/loading/util";
 
@@ -59,9 +56,6 @@ export const ContractInstanceDetails: FC = () => {
     );
   }
 
-  const { verifiedDeploymentArguments, deployerMetadata, aztecScanNotes } =
-    getVerifiedContractInstanceDeploymentData(contractInstanceDetails);
-
   return (
     <div className="mx-auto px-[70px] max-w-[1440px]">
       <div className="flex flex-col gap-4 mt-8">
@@ -89,11 +83,7 @@ export const ContractInstanceDetails: FC = () => {
         </div>
       </div>
       <div className="mt-5">
-        <TabsSection
-          verifiedDeploymentData={verifiedDeploymentArguments}
-          deployerMetadata={deployerMetadata}
-          aztecScanNotes={aztecScanNotes}
-        />
+        <TabsSection contractInstanceDetails={contractInstanceDetails} />
       </div>
     </div>
   );

--- a/services/explorer-ui/src/pages/contract-instance-details/tabs-section.tsx
+++ b/services/explorer-ui/src/pages/contract-instance-details/tabs-section.tsx
@@ -80,7 +80,7 @@ export const TabsSection: FC<PillSectionProps> = ({
         onOptionSelect={onOptionSelect}
         selectedItem={selectedTab}
       />
-      {hasAnyAvailableOptions ?? (
+      {hasAnyAvailableOptions && (
         <div className="bg-white rounded-lg shadow-md p-4">
           <div className="flex flex-col gap-4 md:flex-row ">
             <div className="bg-white w-full rounded-lg">

--- a/services/explorer-ui/src/pages/contract-instance-details/tabs-section.tsx
+++ b/services/explorer-ui/src/pages/contract-instance-details/tabs-section.tsx
@@ -1,44 +1,77 @@
 import { useState, type FC } from "react";
-import {
-  KeyValueDisplay,
-  type DetailItem,
-} from "~/components/info-display/key-value-display";
+import { KeyValueDisplay } from "~/components/info-display/key-value-display";
 import { OptionButtons } from "~/components/option-buttons";
 import { verifiedDeploymentTabs, type TabId } from "./types";
+import { type ChicmozL2ContractInstanceDeluxe } from "@chicmoz-pkg/types";
+import { getVerifiedContractInstanceDeploymentData } from "./util";
+import { useContractClass } from "~/hooks";
+import { Loader } from "~/components/loader";
+import { ArtifactJsonTab } from "../contract-class-details/tabs/artifact-json-tab";
+import { ArtifactExplorerTab } from "../contract-class-details/tabs/artifact-explorer-tab";
 
 interface PillSectionProps {
-  verifiedDeploymentData?: DetailItem[];
-  deployerMetadata?: DetailItem[];
-  aztecScanNotes?: DetailItem[];
+  contractInstanceDetails: ChicmozL2ContractInstanceDeluxe;
 }
 export const TabsSection: FC<PillSectionProps> = ({
-  verifiedDeploymentData,
-  deployerMetadata,
-  aztecScanNotes,
+  contractInstanceDetails,
 }) => {
+  const { verifiedDeploymentArguments, deployerMetadata, aztecScanNotes } =
+    getVerifiedContractInstanceDeploymentData(contractInstanceDetails);
+
+  const selectedVersionWithArtifactRes = useContractClass({
+    classId: contractInstanceDetails.originalContractClassId,
+    version: contractInstanceDetails.version.toString(),
+    includeArtifactJson: true,
+  });
   const [selectedTab, setSelectedTab] = useState<TabId>("verifiedDeployment");
   const onOptionSelect = (value: string) => {
     setSelectedTab(value as TabId);
   };
 
   const isAvailable = {
-    verifiedDeployment: !!verifiedDeploymentData,
+    verifiedDeployment: !!verifiedDeploymentArguments,
     contactDetails: !!deployerMetadata,
     aztecScanNotes: !!aztecScanNotes,
+    contractClassArtifect: !!selectedVersionWithArtifactRes.data?.artifactJson,
+    contractClassArtifectExplorer:
+      !!selectedVersionWithArtifactRes.data?.artifactJson,
   };
+
+  // Check if any options are available
+  const hasAnyAvailableOptions = Object.values(isAvailable).some(Boolean);
 
   const renderTabContent = () => {
     switch (selectedTab) {
       case "contactDetails":
         return <KeyValueDisplay data={deployerMetadata ?? []} />;
       case "verifiedDeployment":
-        return <KeyValueDisplay data={verifiedDeploymentData ?? []} />;
+        return <KeyValueDisplay data={verifiedDeploymentArguments ?? []} />;
       case "aztecScanNotes":
         return <KeyValueDisplay data={aztecScanNotes ?? []} />;
+      case "contractClassArtifect":
+        return selectedVersionWithArtifactRes.isLoading ? (
+          <Loader amount={1} />
+        ) : (
+          <ArtifactJsonTab
+            data={selectedVersionWithArtifactRes.data?.artifactJson}
+            artifactHash={
+              selectedVersionWithArtifactRes.data?.artifactHash ?? ""
+            }
+          />
+        );
+      case "contractClassArtifectExplorer":
+        return selectedVersionWithArtifactRes.isLoading ? (
+          <Loader amount={1} />
+        ) : (
+          <ArtifactExplorerTab
+            data={selectedVersionWithArtifactRes.data?.artifactJson}
+          />
+        );
       default:
         return null;
     }
   };
+
   return (
     <>
       <OptionButtons
@@ -47,11 +80,15 @@ export const TabsSection: FC<PillSectionProps> = ({
         onOptionSelect={onOptionSelect}
         selectedItem={selectedTab}
       />
-      <div className="bg-white rounded-lg shadow-md p-4">
-        <div className="flex flex-col gap-4 md:flex-row ">
-          <div className="bg-white w-full rounded-lg">{renderTabContent()}</div>
+      {hasAnyAvailableOptions ?? (
+        <div className="bg-white rounded-lg shadow-md p-4">
+          <div className="flex flex-col gap-4 md:flex-row ">
+            <div className="bg-white w-full rounded-lg">
+              {renderTabContent()}
+            </div>
+          </div>
         </div>
-      </div>
+      )}
     </>
   );
 };

--- a/services/explorer-ui/src/pages/contract-instance-details/types.ts
+++ b/services/explorer-ui/src/pages/contract-instance-details/types.ts
@@ -9,7 +9,6 @@ export const tabIds = [
   "aztecScanNotes",
   "contractClassArtifect",
   "contractClassArtifectExplorer",
-  "contractClassType",
 ] as const;
 
 export const tabIdSchema = z.enum(tabIds);
@@ -27,7 +26,6 @@ export const verifiedDeploymentTabs: Tab[] = [
   { id: "aztecScanNotes", label: "Aztec Scan notes" },
   { id: "contractClassArtifect", label: "Contract Artifect" },
   { id: "contractClassArtifectExplorer", label: "Artifect Explorer" },
-  { id: "contractClassType", label: "Contract type" },
 ];
 
 export interface VerifiedDeploymentData {

--- a/services/explorer-ui/src/pages/contract-instance-details/types.ts
+++ b/services/explorer-ui/src/pages/contract-instance-details/types.ts
@@ -7,6 +7,9 @@ export const tabIds = [
   "verifiedDeployment",
   "contactDetails",
   "aztecScanNotes",
+  "contractClassArtifect",
+  "contractClassArtifectExplorer",
+  "contractClassType",
 ] as const;
 
 export const tabIdSchema = z.enum(tabIds);
@@ -22,6 +25,9 @@ export const verifiedDeploymentTabs: Tab[] = [
   { id: "verifiedDeployment", label: "Verified deployment" },
   { id: "contactDetails", label: "Contact details" },
   { id: "aztecScanNotes", label: "Aztec Scan notes" },
+  { id: "contractClassArtifect", label: "Contract Artifect" },
+  { id: "contractClassArtifectExplorer", label: "Artifect Explorer" },
+  { id: "contractClassType", label: "Contract type" },
 ];
 
 export interface VerifiedDeploymentData {

--- a/services/explorer-ui/src/pages/contract-instance-details/util.tsx
+++ b/services/explorer-ui/src/pages/contract-instance-details/util.tsx
@@ -2,6 +2,9 @@ import {
   type ChicmozContractInstanceBalance,
   type ChicmozL2ContractInstanceDeluxe,
 } from "@chicmoz-pkg/types";
+import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
+import { CustomTooltip } from "~/components/custom-tooltip";
+import { Link } from "@tanstack/react-router";
 import { routes } from "~/routes/__root";
 import { API_URL, aztecExplorer } from "~/service/constants";
 
@@ -13,6 +16,32 @@ export const getContractData = (
   balance?: ChicmozContractInstanceBalance,
 ) => {
   const link = `${routes.contracts.route}${routes.contracts.children.classes.route}/${data.contractClassId}/versions/${data.version}`;
+  const standardContractType = data.standardContractType
+    ? {
+        label: "STANDARD CONTRACT TYPE",
+        value: `${data.standardContractType}${
+          data.standardContractVersion
+            ? ` v${data.standardContractVersion}`
+            : ""
+        }`,
+        tooltip: "Matched with DeFi-Wonderland's standard contracts",
+      }
+    : {
+        label: "STANDARD CONTRACT TYPE",
+        value: "CUSTOM",
+        customValue: (
+          <div className="text-gray-400 dark:text-gray-500 flex flex-grow items-end justify-end gap-1">
+            <CustomTooltip content="If you think this is a standard contract, please let us know!">
+              <Link
+                to={`${routes.contracts.route}/${routes.contracts.children.classes.route}/${data.contractClassId}/${routes.contracts.children.classes.children.id.children.versions.route}/${data.version}/${routes.contracts.children.classes.children.id.children.versions.children.version.children.submitStandardContract.route}`}
+              >
+                <ExclamationTriangleIcon />
+              </Link>
+            </CustomTooltip>
+            Not available
+          </div>
+        ),
+      };
   const displayData = [
     {
       label: "ADDRESS",
@@ -39,6 +68,7 @@ export const getContractData = (
       value: "View raw data",
       extLink: `${API_URL}${aztecExplorer.getL2ContractInstance(data.address)}`,
     },
+    standardContractType,
   ];
   const isDeployerContract =
     process.env.NODE_ENV === "development" &&


### PR DESCRIPTION
## Summary
Enhanced contract instance details page with artifact tabs and contract standard type display, plus improved tab visibility behavior.

## Changes
- Add artifact tabs for contract class exploration
- Display contract standard type in contract instance details
- Hide tab content section when no tabs are available
- Hide separator line in option buttons when no options are available
- Maintain option buttons visibility for consistent UI