### PR TITLE
chore: defi-wonderland version bump v1.1.2

### DIFF
--- a/packages/types/src/aztec/l2Contract.ts
+++ b/packages/types/src/aztec/l2Contract.ts
@@ -118,6 +118,7 @@ export type ChicmozL2UtilityFunctionBroadcastedEvent = z.infer<
 >;
 
 export const CONTRACT_STANDARDS = {
+  "0.0.0-73e84dcc": ["token", "dripper"],
   "0.0.0-83476cda": ["token", "dripper"],
 };
 

--- a/packages/types/src/aztec/l2Contract.ts
+++ b/packages/types/src/aztec/l2Contract.ts
@@ -118,7 +118,7 @@ export type ChicmozL2UtilityFunctionBroadcastedEvent = z.infer<
 >;
 
 export const CONTRACT_STANDARDS = {
-  "0.0.0-73e84dcc": ["token", "dripper"],
+  "0.0.0-83476cda": ["token", "dripper"],
 };
 
 export const contractStandardVersionSchema = z.enum(

--- a/services/event-cannon/package.json
+++ b/services/event-cannon/package.json
@@ -17,7 +17,7 @@
     "@chicmoz-pkg/contract-verification": "workspace:^",
     "@chicmoz-pkg/logger-server": "workspace:^",
     "@chicmoz-pkg/types": "workspace:^",
-    "@defi-wonderland/aztec-standards": "0.0.0-73e84dcc",
+    "@defi-wonderland/aztec-standards": "0.0.0-83476cda",
     "viem": "2.20.0"
   },
   "devDependencies": {

--- a/services/event-cannon/src/cannon/scenarios/deploy-aztec-standard-token-contract.ts
+++ b/services/event-cannon/src/cannon/scenarios/deploy-aztec-standard-token-contract.ts
@@ -1,5 +1,5 @@
 import { type DeploySentTx, waitForPXE } from "@aztec/aztec.js";
-import { TokenContract } from "@defi-wonderland/aztec-standards/historical/0.0.0-73e84dcc/artifacts/artifacts/Token.js";
+import { TokenContract } from "@defi-wonderland/aztec-standards/historical/0.0.0-83476cda/artifacts/artifacts/Token.js";
 import { logger } from "../../logger.js";
 import { getAztecNodeClient, getPxe, getWallets } from "../pxe.js";
 import {

--- a/services/explorer-api/package.json
+++ b/services/explorer-api/package.json
@@ -19,7 +19,7 @@
     "@chicmoz-pkg/postgres-helper": "workspace:^",
     "@chicmoz-pkg/redis-helper": "workspace:^",
     "@chicmoz-pkg/types": "workspace:^",
-    "@defi-wonderland/aztec-standards": "0.0.0-73e84dcc",
+    "@defi-wonderland/aztec-standards": "0.0.0-83476cda",
     "body-parser": "1.20.2",
     "cors": "2.8.5",
     "drizzle-orm": "0.33.0",

--- a/services/explorer-api/src/utils/standard-contracts.ts
+++ b/services/explorer-api/src/utils/standard-contracts.ts
@@ -4,14 +4,14 @@ import {
   ContractStandardName,
   ContractStandardVersion,
 } from "@chicmoz-pkg/types";
-import DripperContractJson from "@defi-wonderland/aztec-standards/historical/0.0.0-73e84dcc/target/dripper-Dripper.json" with { type: "json" };
-import TokenContractJson from "@defi-wonderland/aztec-standards/historical/0.0.0-73e84dcc/target/token_contract-Token.json" with { type: "json" };
+import DripperContractJson from "@defi-wonderland/aztec-standards/historical/0.0.0-83476cda/target/dripper-Dripper.json" with { type: "json" };
+import TokenContractJson from "@defi-wonderland/aztec-standards/historical/0.0.0-83476cda/target/token_contract-Token.json" with { type: "json" };
 
 const contracts: Record<
   ContractStandardVersion,
   Record<ContractStandardName<ContractStandardVersion>, NoirCompiledContract>
 > = {
-  "0.0.0-73e84dcc": {
+  "0.0.0-83476cda": {
     // TODO: these types are not actually checked
     token: TokenContractJson as NoirCompiledContract,
     dripper: DripperContractJson as NoirCompiledContract,

--- a/services/explorer-api/src/utils/standard-contracts.ts
+++ b/services/explorer-api/src/utils/standard-contracts.ts
@@ -4,17 +4,24 @@ import {
   ContractStandardName,
   ContractStandardVersion,
 } from "@chicmoz-pkg/types";
-import DripperContractJson from "@defi-wonderland/aztec-standards/historical/0.0.0-83476cda/target/dripper-Dripper.json" with { type: "json" };
-import TokenContractJson from "@defi-wonderland/aztec-standards/historical/0.0.0-83476cda/target/token_contract-Token.json" with { type: "json" };
+import DripperContractJsonV1 from "@defi-wonderland/aztec-standards/historical/0.0.0-83476cda/target/dripper-Dripper.json" with { type: "json" };
+import TokenContractJsonV1 from "@defi-wonderland/aztec-standards/historical/0.0.0-83476cda/target/token_contract-Token.json" with { type: "json" };
+import DripperContractJsonV083 from "@defi-wonderland/aztec-standards/historical/0.0.0-73e84dcc/target/dripper-Dripper.json" with { type: "json" };
+import TokenContractJsonV083 from "@defi-wonderland/aztec-standards/historical/0.0.0-73e84dcc/target/token_contract-Token.json" with { type: "json" };
 
 const contracts: Record<
   ContractStandardVersion,
   Record<ContractStandardName<ContractStandardVersion>, NoirCompiledContract>
 > = {
+  "0.0.0-73e84dcc": {
+    // TODO: these types are not actually checked
+    token: TokenContractJsonV083 as NoirCompiledContract,
+    dripper: DripperContractJsonV083 as NoirCompiledContract,
+  },
   "0.0.0-83476cda": {
     // TODO: these types are not actually checked
-    token: TokenContractJson as NoirCompiledContract,
-    dripper: DripperContractJson as NoirCompiledContract,
+    token: TokenContractJsonV1 as NoirCompiledContract,
+    dripper: DripperContractJsonV1 as NoirCompiledContract,
   },
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,7 +1154,7 @@ __metadata:
     "@chicmoz-pkg/contract-verification": "workspace:^"
     "@chicmoz-pkg/logger-server": "workspace:^"
     "@chicmoz-pkg/types": "workspace:^"
-    "@defi-wonderland/aztec-standards": "npm:0.0.0-73e84dcc"
+    "@defi-wonderland/aztec-standards": "npm:0.0.0-83476cda"
     "@types/node": "npm:20.5.0"
     "@typescript-eslint/eslint-plugin": "npm:6.11.0"
     "@typescript-eslint/parser": "npm:6.11.0"
@@ -1187,7 +1187,7 @@ __metadata:
     "@chicmoz-pkg/postgres-helper": "workspace:^"
     "@chicmoz-pkg/redis-helper": "workspace:^"
     "@chicmoz-pkg/types": "workspace:^"
-    "@defi-wonderland/aztec-standards": "npm:0.0.0-73e84dcc"
+    "@defi-wonderland/aztec-standards": "npm:0.0.0-83476cda"
     "@types/auto-bind": "npm:2.1.0"
     "@types/body-parser": "npm:1.19.5"
     "@types/cors": "npm:2.8.13"
@@ -1335,10 +1335,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@defi-wonderland/aztec-standards@npm:0.0.0-73e84dcc":
-  version: 0.0.0-73e84dcc
-  resolution: "@defi-wonderland/aztec-standards@npm:0.0.0-73e84dcc"
-  checksum: 7fa0744494f17b3f31faddecf346c408ebd5d1d1a86f89dfff12ce0929594a4fff8c71aecb4839076e2d9f0fe2d611de5c0b4eea369bc6e131c8a32e41c76c56
+"@defi-wonderland/aztec-standards@npm:0.0.0-83476cda":
+  version: 0.0.0-83476cda
+  resolution: "@defi-wonderland/aztec-standards@npm:0.0.0-83476cda"
+  checksum: 813ee485b8f40bb1165777aa1355983ebed46e9882dc7545c929fe63c7c5324f26b798888dfad0e705dcf981d03382ee662bff0fbd9bdccb4c2f11ae63382f5e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pr updates the defi-wonderland package to the newest version v1.1.2